### PR TITLE
docs: sync phase flow in README with agents.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Dory relies on configuration to maintain execution speed and precision.
 
 * **Intent-First:** The model prioritizes structural goals over literal text.
 * **Zero-Padding:** No conversational wrapping. Output code blocks directly.
-* **Decomposition:** Explicit `[PLANNING]` ➔ `[IMPLEMENTING]` ➔ `[TESTING]` flow for complex tasks. This is optional for small or isolated requests.
+* **Decomposition:** Explicit `[PLANNING]` ➔ `[IMPLEMENTING]` ➔ `[TESTING]` ➔ `[ITERATING]` flow for complex tasks. This is optional for small or isolated requests.
 
 #### II. Tactical Engineering
 


### PR DESCRIPTION
README.md's Decomposition bullet lists three phases (PLANNING, IMPLEMENTING, TESTING) but agents.md defines four, including ITERATING. This brings the README in line with the actual spec.